### PR TITLE
Update splunk query for sysmon detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The provided Sysmon configuration [CVE-2021-1675.xml](CVE-2021-1675.xml) file ca
 # Splunk Query
 
 ```xml
-index=sysmon Image="C:\\Windows\\System32\\spoolsv.exe" 
+index=sysmon EventCode=7 Image="C:\\Windows\\System32\\spoolsv.exe" NOT (Signature="Microsoft Windows" SignatureStatus=Valid)
 | stats values(ImageLoaded),values(TargetObject),values(Details),values(TargetFilename)
 ```
 


### PR DESCRIPTION
I suggest to make query about sysmon detection more precise: detect only "Image loaded" events (Event ID 7).
Also there will be ligitimate noise, so I sugest to filter out events about loading DLLs that were signed by Microsoft.
[Example of legitimate noise](https://ibb.co/ChLZRXd)